### PR TITLE
Dedent() remove surrounding newlines

### DIFF
--- a/dedent.go
+++ b/dedent.go
@@ -45,5 +45,10 @@ func Dedent(text string) string {
 	if margin != "" {
 		text = regexp.MustCompile("(?m)^"+margin).ReplaceAllString(text, "")
 	}
+
+	if text[0] == '\n' && text[len(text)-1] == '\n' {
+		text = text[1 : len(text)-1]
+	}
+
 	return text
 }

--- a/dedent_test.go
+++ b/dedent_test.go
@@ -65,11 +65,9 @@ func TestDedentUneven(t *testing.T) {
 				while 1:
 					return foo
 			`,
-			expect: `
-def foo():
+			expect: `def foo():
 	while 1:
-		return foo
-`,
+		return foo`,
 		},
 		{
 			// Uneven indentation with a blank line
@@ -141,6 +139,39 @@ func TestDedentPreserveMarginTabs(t *testing.T) {
 	}
 
 	for _, text := range texts2 {
+		if text.expect != Dedent(text.text) {
+			t.Errorf(errorMsg, text.expect, Dedent(text.text))
+		}
+	}
+}
+
+// Dedent() should remove the first and last newline if it starts and ends with a newline
+func TestDedentRemoveSurroundingNewLines(t *testing.T) {
+	texts := []dedentTest{
+		{
+			text: `
+				hello there
+				how are you?
+			`,
+			expect: "hello there\nhow are you?",
+		},
+		{
+			text: `
+
+				hello there
+				how are you?
+			`,
+			expect: "\nhello there\nhow are you?",
+		},
+		{
+			text: `
+				hello there
+				how are you?`,
+			expect: "\nhello there\nhow are you?",
+		},
+	}
+
+	for _, text := range texts {
 		if text.expect != Dedent(text.text) {
 			t.Errorf(errorMsg, text.expect, Dedent(text.text))
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/lithammer/dedent
+
+go 1.13


### PR DESCRIPTION
**Breaking change!** I realise that this would be a breaking change that you might not desire. I'm happy using my fork of this library for my own projects, but I wanted to know your thoughts on this, and if you'd be interested in merging it in or altering this to be a backward compatible change (e.g. adding a new method that does the `Dedent` + newline trimming.)

---

The most common use-case for Dedent() is a situation like:

    multiLineString = dedent.Dedent(`
        This is a
        multi-line string.
    `)

Most programmers would reasonably expect multiLineString to be equal to `"This is a\nmulti-line string."` Currently Dedent() returns `"\nThis is a\nmulti-line string.\n"`. When using raw string syntax, there is currently no good way to specify a multi-line string without a "\n". This commit strips a "\n" prefix and suffix, only if the string has both a "\n" prefix and a "\n" suffix.
