### PR TITLE
Removing leading NL, compatible with Python textwrap.dedent("""\.

### DIFF
--- a/dedent.go
+++ b/dedent.go
@@ -6,6 +6,7 @@ import (
 )
 
 var (
+	leadingNewline    = regexp.MustCompile("^[\n]")
 	whitespaceOnly    = regexp.MustCompile("(?m)^[ \t]+$")
 	leadingWhitespace = regexp.MustCompile("(?m)(^[ \t]*)(?:[^ \t\n])")
 )
@@ -18,6 +19,7 @@ var (
 func Dedent(text string) string {
 	var margin string
 
+	text = leadingNewline.ReplaceAllString(text, "")
 	text = whitespaceOnly.ReplaceAllString(text, "")
 	indents := leadingWhitespace.FindAllStringSubmatch(text, -1)
 

--- a/dedent_test.go
+++ b/dedent_test.go
@@ -65,8 +65,7 @@ func TestDedentUneven(t *testing.T) {
 				while 1:
 					return foo
 			`,
-			expect: `
-def foo():
+			expect: `def foo():
 	while 1:
 		return foo
 `,
@@ -153,10 +152,12 @@ func ExampleDedent() {
 		consectetur adipiscing elit.
 		Curabitur justo tellus, facilisis nec efficitur dictum,
 		fermentum vitae ligula. Sed eu convallis sapien.`
+	fmt.Println("-------------")
 	fmt.Println(Dedent(s))
 	fmt.Println("-------------")
 	fmt.Println(s)
 	// Output:
+	// -------------
 	// Lorem ipsum dolor sit amet,
 	// consectetur adipiscing elit.
 	// Curabitur justo tellus, facilisis nec efficitur dictum,


### PR DESCRIPTION
(sorry for the previous polluted pull request, my git-fu seems to be weak!)