### PR TITLE
Support the case where first line is not indented, like python's dedent

### DIFF
--- a/dedent.go
+++ b/dedent.go
@@ -22,9 +22,13 @@ func Dedent(text string) string {
 	indents := leadingWhitespace.FindAllStringSubmatch(text, -1)
 
 	// Look for the longest leading string of spaces and tabs common to all
-	// lines.
+	// lines, except first non-indented lines.
+	firstIndentedLine := 0
 	for i, indent := range indents {
-		if i == 0 {
+		if i == firstIndentedLine && indent[1] == "" {
+			// no indent in first line, ignore it
+			firstIndentedLine = 1
+		} else if i == firstIndentedLine {
 			margin = indent[1]
 		} else if strings.HasPrefix(indent[1], margin) {
 			// Current line more deeply indented than previous winner:


### PR DESCRIPTION
Will work with 
```
a := dedent.Dedent(`
        asdfasdfasfd 
        asdfasdfasdfasdf asdf asdf`
    )
b := dedent.Dedent(`asdfasdfasfd 
        asdfasdfasdfasdf asdf asdf`
    )
```